### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ WORKDIR /var/www/html
 RUN apt-get update -y && \
   apt-get install -y --no-install-recommends \
   curl git openssl \
-  less vim wget unzip rsync git mysql-client \
+  less vim wget unzip rsync git default-mysql-client \
   libcurl4-openssl-dev libfreetype6 libjpeg62-turbo libpng-dev libjpeg-dev libxml2-dev libxpm4 \
   libicu-dev coreutils openssh-client libsqlite3-dev && \
   apt-get clean && \


### PR DESCRIPTION
php:7-fpm now use Debian 10 (Buster) as its base image and Buster ships with MariaDB, so I replaced mysql-client with default-mysql-client to fix it.